### PR TITLE
Use C.CBytes at data variable for simple data pass-through

### DIFF
--- a/examples/in_gdummy/in_gdummy.go
+++ b/examples/in_gdummy/in_gdummy.go
@@ -7,21 +7,10 @@ import "C"
 import (
 	"fmt"
 	"time"
-	"reflect"
 	"unsafe"
 
 	"github.com/fluent/fluent-bit-go/input"
 )
-
-type Slice struct {
-	Data []byte
-	data *c_slice_t
-}
-
-type c_slice_t struct {
-	p unsafe.Pointer
-	n int
-}
 
 //export FLBPluginRegister
 func FLBPluginRegister(def unsafe.Pointer) int {
@@ -36,22 +25,6 @@ func FLBPluginInit(plugin unsafe.Pointer) int {
 	param := input.FLBPluginConfigKey(plugin, "param")
 	fmt.Printf("[flb-go] plugin parameter = '%s'\n", param)
 	return input.FLB_OK
-}
-
-func alloc(size int) unsafe.Pointer {
-	return C.calloc(C.size_t(size), 1)
-}
-
-func makeSlice(p unsafe.Pointer, n int) *Slice {
-	data := &c_slice_t{p: p, n: n}
-
-	s := &Slice{data: data}
-	h := (*reflect.SliceHeader)(unsafe.Pointer(&s.Data))
-	h.Data = uintptr(p)
-	h.Len = n
-	h.Cap = n
-
-	return s
 }
 
 //export FLBPluginInputCallback
@@ -70,10 +43,7 @@ func FLBPluginInputCallback(data *unsafe.Pointer, size *C.size_t) int {
 	}
 
 	length := len(packed)
-	p := alloc(length)
-	s := makeSlice(p, length)
-	copy(s.Data, packed)
-	*data = unsafe.Pointer(&s.Data[0])
+	*data = C.CBytes(packed)
 	*size = C.size_t(length)
 	// For emitting interval adjustment.
 	time.Sleep(1000 * time.Millisecond)


### PR DESCRIPTION
This patch is pointed out in https://github.com/fluent/fluent-bit-go/pull/52#pullrequestreview-915093759.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>